### PR TITLE
Fixes: #27

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -462,9 +462,10 @@ local function on_runtime_mod_setting_changed(e)
         return
     end
     local player_index = e.player_index
+    if not player_index then return end
     local player = game.get_player(player_index)
     local pdata = global._pdata[player_index]
-    if not (player_index and pdata) then return end
+    if not pdata then return end
     player_data.refresh(player, pdata)
     at_gui.update_main_button(player, pdata)
     if e.setting == "autotrash_gui_displayed_columns" then


### PR DESCRIPTION
I don't know if the fix needs to be more extensive than this.

https://lua-api.factorio.com/1.1.19/events.html#on_runtime_mod_setting_changed indicates that e.player_index is expected to be nil if a script changes the setting.

on_runtime_mod_setting_changed
Called when a runtime mod setting is changed by a player.

Contains
player_index :: uint (optional): The player who changed the setting or nil if changed by script.
setting :: string: The setting name that changed.
setting_type :: string: The setting type: "runtime-per-user", or "runtime-global".