### PR TITLE
Exclude spidertron remotes from autotrash

### DIFF
--- a/constants.lua
+++ b/constants.lua
@@ -20,6 +20,7 @@ constants.trash_blacklist = {
     ["upgrade-item"] = true,
     ["copy-paste-tool"] = true,
     ["selection-tool"] = true,
+    ["spidertron-remote"] = true,
 }
 
 constants.gui_dimensions = {

--- a/scripts/global-data.lua
+++ b/scripts/global-data.lua
@@ -18,6 +18,7 @@ function global_data.refresh()
         {filter = "type", type = "upgrade-item", invert = true, mode = "and"},
         {filter = "type", type = "copy-paste-tool", invert = true, mode = "and"},
         {filter = "type", type = "selection-tool", invert = true, mode = "and"},
+        {filter = "type", type = "spidertron-remote", invert = true, mode = "and"},
         {filter = "flag", flag = "hidden", invert = true, mode = "and"},
         --{filter = "place-result", mode = "and"}
     }


### PR DESCRIPTION
Howdy, I just noticed that this mod caused my spidertron remotes to constantly get yoinked from me, and those are important, so I made this little change :)