### PR TITLE
Insert current preset name in textfield

### DIFF
--- a/scripts/gui.lua
+++ b/scripts/gui.lua
@@ -634,6 +634,8 @@ at_gui.handlers.presets = {
         local player = e.player
         local pdata = e.pdata
         local name = e.element.caption
+        local textfield = pdata.gui.presets.textfield
+        textfield.text = name
         if not e.shift then
             pdata.selected_presets = {[name] = true}
             pdata.config_tmp = at_util.copy_preset(pdata.presets[name])


### PR DESCRIPTION
Seems like this would make it a lot more streamlined to load/edit/update presets - not having to manually type in the preset name to update it.


https://user-images.githubusercontent.com/4523694/229366865-2fc4c18e-7b00-463f-ab78-d9f9801b4450.mp4

